### PR TITLE
feature: lambda logs are only kept for 30 days (default)

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -29,6 +29,8 @@ instances of this stack for different environments and regions.
 * `python_version` - Python version to be used. Defaults to 2.7
 Default is once a day at 03:00 GMT.
 See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+* `lambda_logs_retention_in_days` - How many days should the logs of the lambda 
+function be kept. Default is 30 days.
 
 ## Usage
 

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -17,3 +17,9 @@ resource "aws_lambda_permission" "allow_cloudwatch" {
   principal     = "events.amazonaws.com"
   source_arn    = "${aws_cloudwatch_event_rule.schedule.arn}"
 }
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name = "/aws/lambda/${var.prefix}es-cleanup"
+
+  retention_in_days = "${var.lambda_logs_retention_in_days}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,8 +1,14 @@
-variable "prefix" {  default = "" }
+variable "prefix" {
+  default = ""
+}
 
-variable "schedule" { default = "cron(0 3 * * ? *)" }
+variable "schedule" {
+  default = "cron(0 3 * * ? *)"
+}
 
-variable "sns_alert" { default = "" }
+variable "sns_alert" {
+  default = ""
+}
 
 variable "es_endpoint" {}
 
@@ -12,4 +18,10 @@ variable "delete_after" {}
 
 variable "index_format" {}
 
-variable "python_version" { default = "2.7" }
+variable "python_version" {
+  default = "2.7"
+}
+
+variable "lambda_logs_retention_in_days" {
+  default = 30
+}


### PR DESCRIPTION
for https://github.com/skyscrapers/engineering/issues/35